### PR TITLE
Soft 404 detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ chardet==4.0.0
 pycld2==0.41
 python-magic==0.4.25
 regex==2022.1.18
+soft-404==0.4.0

--- a/tests/test_warc_metadata_sidecar.py
+++ b/tests/test_warc_metadata_sidecar.py
@@ -76,6 +76,12 @@ def test_unknown_language():
     assert language is None
 
 
+def test_determine_sof404():
+    soft404_page = b'<h1>Page Not Found<h1>'
+    detected = sidecar.determine_soft404(soft404_page)
+    assert detected
+
+
 def test_create_warcinfo_payload():
     publisher = 'University of North Texas - Digital Projects Unit'
     warcinfo = sidecar.create_warcinfo_payload('sample.warc', None, publisher)
@@ -87,12 +93,14 @@ def test_create_string_payload():
     puid = 'fmt/471'
     result_dict = {'encoding': 'ascii', 'confidence': 1.0}
     lang_cld = RECORD_LANG_DICT
-    payload = sidecar.create_string_payload(mime_dict, puid, result_dict, lang_cld)
-    assert payload == '{0} {1}\n{2} {3}\n{4} {5}\n{6} {7}'.format(
+    soft_404 = '0.022243212227210058'
+    payload = sidecar.create_string_payload(mime_dict, puid, result_dict, lang_cld, soft_404)
+    assert payload == '{0} {1}\n{2} {3}\n{4} {5}\n{6} {7}\n{8} {9}'.format(
                             sidecar.MIME_TITLE, mime_dict,
                             sidecar.PUID_TITLE, puid,
                             sidecar.CHARSET_TITLE, result_dict,
-                            sidecar.LANGUAGE_TITLE, lang_cld)
+                            sidecar.LANGUAGE_TITLE, lang_cld,
+                            sidecar.SOFT404_TITLE, soft_404)
 
 
 class Test_Warc_Metadata_Sidecar:
@@ -136,13 +144,15 @@ class Test_Warc_Metadata_Sidecar:
 
     @patch('warc_metadata_sidecar.find_character_set')
     @patch('warc_metadata_sidecar.find_language')
-    def test_metadata_sidecar_image_record(self, mock_language, mock_character, tmpdir):
+    @patch('warc_metadata_sidecar.determine_soft404')
+    def test_metadata_sidecar_image_record(self, mock_404, mock_language, mock_character, tmpdir):
         img_payload = '{0} {1}\n{2} {3}'.format(
                             sidecar.MIME_TITLE, {'fido': 'image/gif', 'python-magic': 'image/gif'},
                             sidecar.PUID_TITLE, 'fmt/4').encode('utf-8')
         sidecar.metadata_sidecar(str(tmpdir), IMAGE_TEST_FILE)
         mock_language.assert_not_called()
         mock_character.assert_not_called()
+        mock_404.assert_not_called()
         assert tmpdir / 'gif.warc.meta.gz' in tmpdir.listdir()
         path = os.path.join(tmpdir / 'gif.warc.meta.gz')
         with open(path, 'rb') as stream:

--- a/warc_metadata_sidecar.py
+++ b/warc_metadata_sidecar.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 import chardet
 import magic
 import pycld2 as cld2
+import soft404
 from fido.fido import Fido
 from warcio.archiveiterator import ArchiveIterator
 from warcio.warcwriter import WARCWriter
@@ -22,12 +23,15 @@ MIME_TITLE = 'Identified-Payload-Type:'
 PUID_TITLE = 'Preservation-Identifier:'
 CHARSET_TITLE = 'Charset-Detected:'
 LANGUAGE_TITLE = 'Languages-cld2:'
+SOFT404_TITLE = 'Soft-404-Detected:'
 
 BAD_CHARS = regex.compile(r'\p{Cc}|\p{Cs}|\p{Cn}')
 
 TEXT_FORMAT_MIMES = re.compile(r'(text|html|xml)')  # this may change
 
 ARC = re.compile(r'.*\.arc(\.gz)?$')
+
+DNS = re.compile(r'^dns:')
 
 
 class ExtendFido(Fido):
@@ -112,6 +116,15 @@ def find_language(bytes_load):
         return None
 
 
+def determine_soft404(bytes_payload):
+    """Detect if the record is a soft 404 record."""
+    detected = soft404.probability(bytes_payload.decode('utf-8', 'replace'))
+    if detected:
+        return detected
+    else:
+        return None
+
+
 def create_warcinfo_payload(new_file, operator=None, publisher=None):
     """Collect WARC fields to create warcinfo record payload."""
     hostname = socket.gethostname()
@@ -130,7 +143,7 @@ def create_warcinfo_payload(new_file, operator=None, publisher=None):
     return warcinfo_payload
 
 
-def create_string_payload(mime_dict, puid, result_dict, lang_cld):
+def create_string_payload(mime_dict, puid, result_dict, lang_cld, soft404):
     """Collect content mime, puid, encoding, and language to create record payload."""
     payload = []
     if mime_dict:
@@ -141,6 +154,8 @@ def create_string_payload(mime_dict, puid, result_dict, lang_cld):
         payload.append('{0} {1}'.format(CHARSET_TITLE, result_dict))
     if lang_cld:
         payload.append('{0} {1}'.format(LANGUAGE_TITLE, lang_cld))
+    if soft404:
+        payload.append('{0} {1}'.format(SOFT404_TITLE, soft404))
     return '\n'.join(payload)
 
 
@@ -188,12 +203,15 @@ def metadata_sidecar(archive_dir, warc_file, operator=None, publisher=None):
                 continue
             if 'text/dns' in record.rec_headers.get_header('Content-Type'):
                 continue
-            payload = io.BytesIO(record.content_stream().read())
+            # Determine if record is a dns, specifically for ARC records.
+            url = record.rec_headers.get_header('WARC-Target-URI')
+            if DNS.match(url):
+                continue
             # The payload is how we find the important info. Skip record if empty.
+            payload = io.BytesIO(record.content_stream().read())
             if not payload.read(1):
                 continue
             # Define specific warc_headers to include in sidecar.
-            url = record.rec_headers.get_header('WARC-Target-URI')
             record_date = record.rec_headers.get_header('WARC-Date')
             if warc:
                 warcinfo_id = record.rec_headers.get_header('WARC-Warcinfo-ID')
@@ -207,10 +225,17 @@ def metadata_sidecar(archive_dir, warc_file, operator=None, publisher=None):
             print(url)
             payload.seek(0)
             mime_dict, puid = find_mime_and_puid(fido, payload)
+            mimes_found = ' '.join(mime_dict.values())
+            soft404_detected = None
             result_dict = {}
             lang_cld = None
+            # Determine the soft404 probability on html records.
+            status = record.http_headers.get_statuscode()
+            if status == '200' and 'html' in mimes_found:
+                payload.seek(0)
+                soft404_detected = determine_soft404(payload.read())
             # If these text formats are in the mime type(s), find the encoding and language.
-            if TEXT_FORMAT_MIMES.search(' '.join(mime_dict.values())):
+            if TEXT_FORMAT_MIMES.search(mimes_found):
                 payload.seek(0)
                 bytes_payload = payload.read()
                 result_dict = find_character_set(bytes_payload)
@@ -218,7 +243,8 @@ def metadata_sidecar(archive_dir, warc_file, operator=None, publisher=None):
                 text_mime += 1
             else:
                 non_text += 1
-            string_payload = create_string_payload(mime_dict, puid, result_dict, lang_cld)
+            string_payload = create_string_payload(mime_dict, puid, result_dict,
+                                                   lang_cld, soft404_detected)
             if not string_payload:
                 continue
             record_count += 1

--- a/warc_metadata_sidecar.py
+++ b/warc_metadata_sidecar.py
@@ -117,7 +117,7 @@ def find_language(bytes_load):
 
 
 def determine_soft404(bytes_payload):
-    """Detect if the record is a soft 404 record."""
+    """Determine the probability of the record being a soft 404 record."""
     detected = soft404.probability(bytes_payload.decode('utf-8', 'replace'))
     if detected:
         return detected


### PR DESCRIPTION
Closes #4 
We have added a soft404 detection tool to determine the probability of a record being a Soft-404 page. The records to be determined will have a status of 200 and mime type of html.

I also noticed that the ARC dns records weren't being caught, so I added an if statement to help with that.