### PR TITLE
Add puid to merged cdxj

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,9 +11,9 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Example:
 ## merge_cdxj.py
 
 This script will take a CDXJ from an original WARC and a metadata sidecar CDXJ, find the matching URI and
-timestamp from each file, collect certain fields from the metadata sidecar CDXJ (mime type,
+timestamp from each file, collect certain fields from the metadata sidecar CDXJ (mime type, puid,
 charset, language, and soft-404), merge those fields with the original CDXJ data, and put the
 merged data into a new CDXJ.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For usage instructions run:
 
 Example:
 
-    $ merge_cdxj.py sidecar.cdxj original.cdxj directory_name
+    $ merge_cdxj.py -m sidecar.cdxj -w original.cdxj -d directory_name
 
 ## Testing
 

--- a/merge_cdxj.py
+++ b/merge_cdxj.py
@@ -29,7 +29,7 @@ def get_alpha3_language_codes(lang_list):
 
 def get_sidecar_fields(original_obj, meta_obj):
     """Collect the sidecar fields and add them to the original WARC dict.
-    
+
     Sidecar fields to collect: mime, puid, charset, languages, and soft404
     """
     if meta_obj.get('Identified-Payload-Type'):

--- a/merge_cdxj.py
+++ b/merge_cdxj.py
@@ -28,7 +28,10 @@ def get_alpha3_language_codes(lang_list):
 
 
 def get_sidecar_fields(original_obj, meta_obj):
-    """Collect the mime, charset, languages, and soft404 to add them to the original WARC dict."""
+    """Collect the sidecar fields and add them to the original WARC dict.
+    
+    Sidecar fields to collect: mime, puid, charset, languages, and soft404
+    """
     if meta_obj.get('Identified-Payload-Type'):
         # Choosing python-magic over fido, due to broader choices.
         if meta_obj['Identified-Payload-Type'].get('python-magic'):
@@ -36,6 +39,9 @@ def get_sidecar_fields(original_obj, meta_obj):
         else:
             mime = meta_obj['Identified-Payload-Type']['fido']
         original_obj['mime-detected'] = mime
+    if meta_obj.get('Preservation-Identifier'):
+        puid = meta_obj['Preservation-Identifier']
+        original_obj['puid'] = puid
     if meta_obj.get('Charset-Detected'):
         charset = meta_obj['Charset-Detected']['encoding']
         original_obj['charset'] = charset

--- a/tests/test_merge_cdxj.py
+++ b/tests/test_merge_cdxj.py
@@ -77,7 +77,7 @@ def test_get_all_sidecar_fields(m_alpha):
     actual = merge_cdxj.get_sidecar_fields(original_obj, meta_obj)
     assert actual['mime-detected'] != 'application/xhtml+xml'
     assert actual == {'mime': 'text/html', 'mime-detected': 'text/html', 'puid': 'fmt/102',
-                      'charset': 'ascii', 'languages': 'eng', 
+                      'charset': 'ascii', 'languages': 'eng',
                       'soft-404-detected': 0.03782088786303804}
     m_alpha.assert_called_once_with(lang_list)
 

--- a/tests/test_merge_cdxj.py
+++ b/tests/test_merge_cdxj.py
@@ -32,8 +32,8 @@ META_DICT = {'com,example) 20091111212121':
 
 MERGED_LIST = ['com,example) 20091111212121 {"url": "http://www.example.com", '
                '"mime": "text/html", "mime-detected": "text/html", '
-               '"charset": "ascii", "languages": "eng", '
-               '"soft-404-detected": 0.08195022044249829}\n']
+               '"puid": "fmt/96", "charset": "ascii", '
+               '"languages": "eng", "soft-404-detected": 0.08195022044249829}\n']
 
 META_FILE = io.StringIO('com,example) 20091111212121 {"Identified-Payload-Type": \
                                 {"fido": "text/html", "python-magic": "text/html"}, \
@@ -76,8 +76,9 @@ def test_get_all_sidecar_fields(m_alpha):
                 'Soft-404-Detected': 0.03782088786303804}
     actual = merge_cdxj.get_sidecar_fields(original_obj, meta_obj)
     assert actual['mime-detected'] != 'application/xhtml+xml'
-    assert actual == {'mime': 'text/html', 'mime-detected': 'text/html', 'charset': 'ascii',
-                      'languages': 'eng', 'soft-404-detected': 0.03782088786303804}
+    assert actual == {'mime': 'text/html', 'mime-detected': 'text/html', 'puid': 'fmt/102',
+                      'charset': 'ascii', 'languages': 'eng', 
+                      'soft-404-detected': 0.03782088786303804}
     m_alpha.assert_called_once_with(lang_list)
 
 
@@ -87,7 +88,7 @@ def test_get_sidecar_fields(m_alpha):
     meta_obj = {'Identified-Payload-Type': {'fido': 'image/gif'},
                 'Preservation-Identifier': 'fmt/4'}
     actual = merge_cdxj.get_sidecar_fields(original_obj, meta_obj)
-    assert actual == {'mime': 'image/gif', 'mime-detected': 'image/gif'}
+    assert actual == {'mime': 'image/gif', 'mime-detected': 'image/gif', 'puid': 'fmt/4'}
     m_alpha.assert_not_called()
 
 
@@ -137,10 +138,12 @@ def test_merge_meta_fields_with_duplicate(m_alpha):
                        '"mime": "text/xml"}\n', newline='\n')
     merged_list = ['com,example) 20091111212121 {"url": "http://www.example.com", '
                    '"mime": "text/html", "mime-detected": "text/html", '
+                   '"puid": "fmt/96", '
                    '"charset": "ascii", "languages": "eng", '
                    '"soft-404-detected": 0.08195022044249829}\n',
                    'com,example) 20091111212121 {"url": "http://www.example.com", '
                    '"mime": "text/xml", "mime-detected": "text/html", '
+                   '"puid": "fmt/96", '
                    '"charset": "ascii", "languages": "eng", '
                    '"soft-404-detected": 0.08195022044249829}\n']
     original, edited, non_edited = merge_cdxj.merge_meta_fields(META_DICT, cdxj)
@@ -168,8 +171,9 @@ def test_merge_cdxj2(m_merge_meta, m_create_dict, caplog, tmpdir):
     meta_file = os.path.join(test_dir, 'meta.cdxj')
     cdxj_file = os.path.join(test_dir, 'warc_1.cdxj')
     expected = ['com,example) 20091111212121 {"url": "http://www.example.com", '
-                '"mime": "text/html", "mime-detected": "text/html", "charset": "ascii", '
-                '"languages": "eng", "soft-404-detected": 0.08195022044249829}\n']
+                '"mime": "text/html", "mime-detected": "text/html", "puid": "fmt/96", '
+                '"charset": "ascii", "languages": "eng", '
+                '"soft-404-detected": 0.08195022044249829}\n']
     caplog.set_level(INFO)
     m_create_dict.return_value = META_DICT
     m_merge_meta.return_value = MERGED_LIST, 1, 0


### PR DESCRIPTION
This closes #24. We are adding the preservation-identifier (puid) to the merged cdxj. I did not capitalize `puid` since none of the other keys are capitalized.

@ldko @somexpert This is ready for review.